### PR TITLE
fix: The Geolocation Map Field in RTL languages in System

### DIFF
--- a/frappe/public/js/lib/leaflet/leaflet.css
+++ b/frappe/public/js/lib/leaflet/leaflet.css
@@ -11,7 +11,6 @@
 .leaflet-image-layer,
 .leaflet-layer {
 	position: absolute;
-	left: 0;
 	top: 0;
 	}
 .leaflet-container {

--- a/frappe/public/js/lib/leaflet/rtl_leaflet.js
+++ b/frappe/public/js/lib/leaflet/rtl_leaflet.js
@@ -1,0 +1,18 @@
+const style = document.createElement('style');
+
+style.textContent = `
+.leaflet-pane,
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-tile-container,
+.leaflet-pane > svg,
+.leaflet-pane > canvas,
+.leaflet-zoom-box,
+.leaflet-image-layer,
+.leaflet-layer {
+	left: 0 ;
+	}
+`;
+
+document.head.appendChild(style);

--- a/frappe/public/js/libs.bundle.js
+++ b/frappe/public/js/libs.bundle.js
@@ -2,6 +2,7 @@ import "./jquery-bootstrap";
 import Vue from "vue/dist/vue.esm.js";
 import "./lib/moment";
 import "../js/lib/leaflet/leaflet.js";
+import "../js/lib/leaflet/rtl_leaflet.js";
 import "../js/lib/leaflet_easy_button/easy-button.js";
 import "../js/lib/leaflet_draw/leaflet.draw.js";
 import "../js/lib/leaflet_control_locate/L.Control.Locate.js";


### PR DESCRIPTION

**Details:**
This pull request introduces a new js file `rtl_leaflet.js` in the `leaflet folder` in public js folder . The existing problem is that OpenStreetMap does not display the entire map in the Geolocation field, when the site language is Arabic .

The new file takes into account the addition of the modification to the css attribute so that it displays the map perfectly and the code is called directly when building the system.

**Screenshots/GIFs:**
**![Before Fix]**
![Screenshot from 2023-08-30 10-46-14](https://github.com/ruknsoftware/frappe/assets/85282854/6d87c80e-34a4-4115-b2e6-c745a7e33884)

**![After Fix]**
![Screenshot from 2023-08-30 10-44-35](https://github.com/ruknsoftware/frappe/assets/85282854/1931cbae-b439-4b2c-a342-61228593db09)


<!-- Provide a visual representation of the behavior change, if applicable -->

**Context:**
This improvement comes in response to multiple user reports about a defect in displaying the map in its designated place after changing the system language to Arabic. 

**Testing Done:**
I've conducted thorough testing on this feature both at the unit level and by performing real-world scenarios in the UI. All tests have passed successfully, and I've verified that revenue calculations are accurate for various sales order scenarios.

<!-- Adding this line will automatically close the related issue upon PR merge -->